### PR TITLE
LGC-1399: success when voiding accrual request with null identifier

### DIFF
--- a/server.js
+++ b/server.js
@@ -111,10 +111,10 @@ http
             return successResponse(res, responseBody);
           case "LOYALTY_REVERSE":
             var info = getPropOrErr(body, "reverseTransactionInformation");
-            identifier = getPropOrErr(info, "loyaltyIdentifier");
+            identifier = info["loyaltyIdentifier"];
             var transactionId = getPropOrErr(info, "transactionId");
             var redemptions = info["redemptions"];
-            reverse(identifier, transactionId, redemptions);
+            if (identifier != null) reverse(identifier, transactionId, redemptions);
             return successResponse(res, responseBody);
           default:
             return errorResponse(res, "ERROR_INVALID_TOAST_TRANSACTION_TYPE");


### PR DESCRIPTION
Fixing the scenario where a loyalty account is added after the check is paid: the logic in cards tries to void the accrual transaction in the ledger generated when the loyalty identifier on the check was null/empty, returning an error.